### PR TITLE
Allow there to be no exclusions

### DIFF
--- a/deployer/s3_sync.py
+++ b/deployer/s3_sync.py
@@ -126,8 +126,9 @@ class s3_sync(object):
                 for dirName, subdirList, fileList in os.walk("%s%s" %(self.base,sync_dir)):
                     thisdir = "".join(dirName.rsplit(self.base)).strip("/")
                     fileList = [os.path.join(dirName,filename) for filename in fileList]
-                    for ignore in self.excludes:
-                        fileList = [n for n in fileList if not fnmatch.fnmatch(n,ignore)] 
+                    if self.excludes:
+                        for ignore in self.excludes:
+                            fileList = [n for n in fileList if not fnmatch.fnmatch(n,ignore)] 
                     count = 0
                     for fname in fileList:
                         dest_key = self.generate_dest_key(fname, thisdir)
@@ -153,8 +154,9 @@ class s3_sync(object):
                 for dirName, subdirList, fileList in os.walk("%s%s" %(self.base,sync_dir)):
                     thisdir = "".join(dirName.rsplit(self.base)).strip("/")
                     fileList = [os.path.join(dirName,filename) for filename in fileList]
-                    for ignore in self.excludes:
-                        fileList = [n for n in fileList if not fnmatch.fnmatch(n,ignore)] 
+                    if self.excludes:
+                        for ignore in self.excludes:
+                            fileList = [n for n in fileList if not fnmatch.fnmatch(n,ignore)] 
                     for fname in fileList:
                         dest_key = self.generate_dest_key(fname, thisdir)
                         if os.name != 'nt':


### PR DESCRIPTION
Added `if self.excludes:` to a few places where it caused deployer to crash when the config file was missing `sync_exclude`.