### PR TITLE
Change node installation process.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ RUN pip install dist/deployer-*.tar.gz
 # Install node
 RUN curl -sL https://rpm.nodesource.com/setup_10.x | bash -
 RUN yum install nodejs -y
-RUN npm -v
 
 # Prep workspace
 RUN mkdir /workspace


### PR DESCRIPTION
Previously the `wget` for Node was getting a 404 because version `12.4.0` was removed from the latest 12.x directory and replaced with `12.6.0`. To fix this, I pulled in the node rpm and installed node with yum which should stop future errors due to version updates.