### PR TITLE
Run off main branch of pipeline shared library

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-library('pipeline-library@feature/add-with-ecr')
+library('pipeline-library')
 
 pipeline {
   options { timestamps() }


### PR DESCRIPTION
The Jenkinsfile previously used the `feature/add-with-ecr` branch of our shared library. When that branch was deleted and merged, it broke this pipeline. This PR just moves over to the main branch.