### PR TITLE
we dont always want to remove docker images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -125,7 +125,6 @@ pipeline {
   }
   post {
     always {
-      removeDockerImages()
       cleanWs()
     }
   }


### PR DESCRIPTION
Builds are slow because we are always re downloading images. 