### PR TITLE
Setup PyPi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,9 @@ RUN yum update -y
 # Setup Deployer
 ADD / /deployer
 WORKDIR /deployer
-RUN python setup.py sdist
-RUN pip install dist/deployer-*.tar.gz
+RUN pip install wheel twine
+RUN python setup.py sdist bdist_wheel
+RUN pip install dist/rbn-deployer-*.tar.gz
 
 # Install node
 RUN curl -sL https://rpm.nodesource.com/setup_10.x | bash -

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,9 +5,11 @@ pipeline {
   agent any
   environment {
     SERVICE = 'deployer'
+    PACKAGE = 'rbn-deployer'
     GITHUB_KEY = 'Deployer'
     GITHUB_URL = 'git@github.com:RightBrain-Networks/deployer.git'
     DOCKER_REGISTRY = '356438515751.dkr.ecr.us-east-1.amazonaws.com'
+    PYPI_CREDENTIALS = 'rbn_pypi_token'
   }
   stages {
     stage('Version') {
@@ -83,10 +85,10 @@ pipeline {
         }
         
         //Copy tar.gz file to s3 bucket
-        sh "aws s3 cp dist/${env.SERVICE}-*.tar.gz s3://rbn-ops-pkg-us-east-1/${env.SERVICE}/${env.SERVICE}-${env.SEMVER_RESOLVED_VERSION}.tar.gz"
+        sh "aws s3 cp dist/${PACKAGE}-*.tar.gz s3://rbn-ops-pkg-us-east-1/${env.SERVICE}/${env.SERVICE}-${env.SEMVER_RESOLVED_VERSION}.tar.gz"
       }
     }
-    stage('GitHub Release')
+    stage('Release')
     {
       when {
           expression {
@@ -96,10 +98,18 @@ pipeline {
       steps
       {
         echo "New version deteced!"
+        createGitHubRelease('rbn-opsGitHubToken', 'RightBrain-Networks/deployer', "${env.SEMVER_RESOLVED_VERSION}",
+          "${env.SEMVER_RESOLVED_VERSION}", ["deployer.tar.gz" : "dist/${PACKAGE}-${env.SEMVER_NEW_VERSION}.tar.gz"])
+
+        // Upload package to PyPi
         script
         {
-          createGitHubRelease('rbn-opsGitHubToken', 'RightBrain-Networks/deployer', "${env.SEMVER_RESOLVED_VERSION}",
-          "${env.SEMVER_RESOLVED_VERSION}", ["deployer.tar.gz" : "dist/deployer-${env.SEMVER_NEW_VERSION}.tar.gz"])
+          docker.image("${env.DOCKER_REGISTRY}/${env.SERVICE}:${env.SEMVER_RESOLVED_VERSION}").inside()
+          {
+            withCredentials([string(credentialsId: env.PYPI_CREDENTIALS, variable: 'PYPI_PASSWORD')]) {
+              sh("twine upload dist/* --verbose -u __token__ -p ${PYPI_PASSWORD}")
+            }
+          }
         }
       }
     }

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def find_version(*file_paths):
     raise RuntimeError("Unable to find version string.")
 
 setup(
-    name='deployer',
+    name='rbn-deployer',
 
     version=find_version('deployer', '__init__.py'),
 


### PR DESCRIPTION
Added push to PyPi on release.

Currently is uses `rbn-deployer` as the project it pushes to, but that can easily be changed by changing the name in `setup.py` and PACKAGE in the `Jenkinsfile`