### PR TITLE
Exit with code '1' on error

### DIFF
--- a/deployer/__init__.py
+++ b/deployer/__init__.py
@@ -185,6 +185,7 @@ def main():
         if args.debug:
             tb = sys.exc_info()[2]
             traceback.print_tb(tb)
+        exit(1)
 
 def find_deploy_path(stackConfig, checkStack, resolved = []):
     #Generate depedency graph


### PR DESCRIPTION
Super simple change that exits with error code `1` when an exception occurs.