### PR TITLE
BUGFIX: Fix stack updates with no bucket

### DIFF
--- a/deployer/configuration.py
+++ b/deployer/configuration.py
@@ -34,7 +34,7 @@ class Config(object):
                         expanded_params.append({ "ParameterKey": param_key, "ParameterValue": param_xform })
             if 'lookup_parameters' in self.config.get(env, {}):
                 for param_key, lookup_struct in self.config[env]['lookup_parameters'].items():
-                    stack = Stack(session, lookup_struct['Stack'], self)
+                    stack = Stack(session, lookup_struct['Stack'], self, None)
                     stack.get_outputs()
                     for output in stack.outputs:
                         if output['OutputKey'] == lookup_struct['OutputKey']:

--- a/deployer/stack.py
+++ b/deployer/stack.py
@@ -19,7 +19,8 @@ class Stack(AbstractCloudFormation):
         self.session = session
         self.stack = stack
         self.config = config
-        self.bucket = bucket
+        if bucket:
+            self.bucket = bucket
 
         # Load values from args
         self.disable_rollback = args.get('disable_rollback', False)
@@ -49,9 +50,10 @@ class Stack(AbstractCloudFormation):
         # Load values from methods
         self.origin = self.get_repository_origin(self.repository) if self.repository else 'null'
         self.identity_arn = self.sts.get_caller_identity().get('Arn', '')
-        self.template_url = self.bucket.construct_template_url(self.config, self.stack, self.release, self.template) # self.construct_template_url()
-        self.template_file = self.bucket.get_template_file(self.config, self.stack)
-        self.template_body = self.bucket.get_template_body(self.config, self.template)
+        if bucket:
+            self.template_url = self.bucket.construct_template_url(self.config, self.stack, self.release, self.template) # self.construct_template_url()
+            self.template_file = self.bucket.get_template_file(self.config, self.stack)
+            self.template_body = self.bucket.get_template_body(self.config, self.template)
 
         # Set state values
         self._timed_out = False

--- a/deployer/tests.py
+++ b/deployer/tests.py
@@ -195,7 +195,7 @@ class DeployerTestCase(unittest.TestCase):
             cloudformation.delete_stack(StackName=testStackName)
         while get_stack_status(testStackName) != "NULL":
             time.sleep(apiHitRate)
-
+        
         # Run deployer -x create with timeout
         result = subprocess.call(['python', deployerExecutor, '-x', 'create', '-c', testStackConfig, '-s', 'timeout', '-T', '1'])
         self.assertEqual(result, 2)
@@ -317,7 +317,7 @@ class IntegrationStackTestCase(unittest.TestCase):
 
     def stack_update(self):
         result = subprocess.call(['deployer', '-x', 'update', '-c', 'tests/config/test.yaml', '-s' 'update', '-P', 'Cli=update', '-D'])
-        self.assertEqual(result, 0)
+        self.assertNotEqual(result, 1)
 
         stack = self.client.describe_stacks(StackName=self.stack_name)
         self.assertIn('Stacks', stack.keys())


### PR DESCRIPTION
Allows stack objects to be passed a `None` type for the bucket so the config object that use the class to get outputs.