### PR TITLE
Explicitly get stack config attributes

### DIFF
--- a/deployer/configuration.py
+++ b/deployer/configuration.py
@@ -72,9 +72,13 @@ class Config(object):
             data = ruamel.yaml.safe_load(f)
         return data
 
-    def get_config_att(self, key, default=None, required=False):
+    def get_config_att(self, key, default=None, required=False, stack=None):
+        ## Default to the current stack if not otherwise specified
+        if not stack:
+            stack = self.stack
+
         base = self.config.get('global', {}).get(key, None)
-        base = self.config.get(self.stack).get(key, base)
+        base = self.config.get(stack).get(key, base)
         if required and base is None:
             logger.error("Required attribute '{}' not found in config '{}'.".format(key, self.file_name))
             exit(3)

--- a/deployer/stack.py
+++ b/deployer/stack.py
@@ -30,7 +30,7 @@ class Stack(AbstractCloudFormation):
         self.params = args.get('params', {})
 
         # Load values from config
-        self.stack_name = self.config.get_config_att('stack_name', required=True)
+        self.stack_name = self.config.get_config_att('stack_name', required=True, stack=self.stack)
         self.base = self.config.get_config_att('sync_base', '.')
 
         # Load values from methods for config lookup


### PR DESCRIPTION
## Changes
Proposed changes add an optional "stack" parameter to get_config_att(). If this parameter is not set, lookup occurs using self.stack, preserving prior functionality.

stack.py is now updated to utilize this parameter to request output from an explicitly supplied stack, i.e.
```python
self.stack_name = self.config.get_config_att('stack_name', required=True, stack=self.stack)
```

## The Problem
When looking up the stackname to use to find outputs, configuration.get_config_att() was always looking up the calling stack, which would not yet exist, instead of the supplied output stack. This was due to the reference to self.stack in get_config_att(). 

## Analysis and Proposed Solution
In StackA.configuration, for example, lets say lookup_struct['Stack'] contains a ref to StackB:
```python            
if 'lookup_parameters' in self.config.get(env, {}):
    for param_key, lookup_struct in self.config[env]['lookup_parameters'].items():
        stack = Stack(session, lookup_struct['Stack'], self, None)
        stack.get_outputs()
```
The *stack* here would correctly be a reference to StackB, however it would critically have the wrong stack_name, StackA's, which would be used for the subsequent get_outputs() call.  

The stack class gets its stack_name by looking it up
```python
self.stack_name = self.config.get_config_att('stack_name', required=True)
```
However, in the case of lookup_params in StackA.configuration.get_config_att(), self.stack is StackA. Although it seems redundant, stack needs to explicitly pass its own self.stack to get_config_att(), to ensure it is getting it's own stack_name, not the stack_name of the stack that called it.
