### PR TITLE
Run semver jobs in container with root permissions

### DIFF
--- a/.github/workflows/deployer-actions.yml
+++ b/.github/workflows/deployer-actions.yml
@@ -21,11 +21,6 @@ jobs:
           with:
             fetch-depth: 0
             ref: ${{ env.GITHUB_REF }}
-        - name: Set up Python 3.7
-          uses: actions/setup-python@v1
-          id: python37
-          with:
-            python-version: 3.7
         - name: Run Auto-Semver
           id: semver
           uses: RightBrain-Networks/semver-action@1.0.0

--- a/.github/workflows/deployer-actions.yml
+++ b/.github/workflows/deployer-actions.yml
@@ -14,7 +14,7 @@ jobs:
     build:
         runs-on: ubuntu-latest
         container:
-          image: debian:latest
+          image: ubuntu:latest
           options: --user root
         steps:
         - name: Installing dependencies..
@@ -47,7 +47,6 @@ jobs:
         - name: Install dependencies
           run: |
             apt update
-            apt install libpython3.7
             python -m pip install --upgrade pip
             pip install -r requirements.txt
         - name: build

--- a/.github/workflows/deployer-actions.yml
+++ b/.github/workflows/deployer-actions.yml
@@ -39,7 +39,6 @@ jobs:
           id: python37
           with:
             python-version: 3.7
-        - run: export LD_LIBRARY_PATH=${{ steps.python37.outputs.python-path }}
         - name: Run Auto-Semver
           id: semver
           uses: RightBrain-Networks/semver-action@1.0.0
@@ -47,6 +46,7 @@ jobs:
             mode: set
         - name: Install dependencies
           run: |
+            which libpython
             python -m pip install --upgrade pip
             pip install -r requirements.txt
         - name: build

--- a/.github/workflows/deployer-actions.yml
+++ b/.github/workflows/deployer-actions.yml
@@ -43,17 +43,10 @@ jobs:
           working-directory: deployer
     CheckVersion:
         runs-on: ubuntu-latest
-        container:
-          image: ubuntu:latest
-          options: --user root
         needs: build
         steps:
         - name: Checkout
           uses: actions/checkout@v2
-        - name: Set up Python 3.7
-          uses: actions/setup-python@v1
-          with:
-            python-version: 3.7
         - name: Run Auto-Semver          
           id: semver
           uses: RightBrain-Networks/semver-action@1.0.0

--- a/.github/workflows/deployer-actions.yml
+++ b/.github/workflows/deployer-actions.yml
@@ -39,7 +39,7 @@ jobs:
           id: python37
           with:
             python-version: 3.7
-        - run: export LD_LIBRARY_PATH='${{ steps.python37.outputs.python-path }}' 
+        - run: export LD_LIBRARY_PATH=${{ steps.python37.outputs.python-path }}
         - name: Run Auto-Semver
           id: semver
           uses: RightBrain-Networks/semver-action@1.0.0
@@ -47,7 +47,6 @@ jobs:
             mode: set
         - name: Install dependencies
           run: |
-            whereis python
             python -m pip install --upgrade pip
             pip install -r requirements.txt
         - name: build

--- a/.github/workflows/deployer-actions.yml
+++ b/.github/workflows/deployer-actions.yml
@@ -46,8 +46,6 @@ jobs:
             mode: set
         - name: Install dependencies
           run: |
-            apt update
-            apt install libpython3.7
             python -m pip install --upgrade pip
             pip install -r requirements.txt
         - name: build

--- a/.github/workflows/deployer-actions.yml
+++ b/.github/workflows/deployer-actions.yml
@@ -41,8 +41,8 @@ jobs:
             mode: set
         - name: Install dependencies
           run: |
-            python -m pip install --upgrade pip
-            pip install -r requirements.txt
+            python -m pip install --upgrade pip -u ubuntu
+            pip install -r requirements.txt -u ubuntu
         - name: build
           run: |
             python setup.py sdist

--- a/.github/workflows/deployer-actions.yml
+++ b/.github/workflows/deployer-actions.yml
@@ -17,20 +17,8 @@ jobs:
           image: python:3.7-bullseye
           options: --user root
         steps:
-          - name: Installing container dependencies..
-            run: |
-              # Sync repos
-              apt update
-              # Install git
-              apt install -y git
-              if ! apt list --installed 2>/dev/null | grep -q "git.*"; then
-                apt install -y git
-              elif apt list --installed 2>/dev/null | grep -q "git.*"; then
-                true
-              else
-                exit 255
-              fi
-          - uses: actions/checkout@v2
+          - name: Checkout
+            uses: actions/checkout@v2
             with:
               fetch-depth: 0
               ref: ${{ env.GITHUB_REF }}
@@ -57,19 +45,6 @@ jobs:
           image: python:3.7-bullseye
           options: --user root
         steps:
-          - name: Installing container dependencies..
-            run: |
-              # Sync repos
-              apt update
-              # Install git
-              apt install -y git
-              if ! apt list --installed 2>/dev/null | grep -q "git.*"; then
-                apt install -y git
-              elif apt list --installed 2>/dev/null | grep -q "git.*"; then
-                true
-              else
-                exit 255
-              fi
           - name: Checkout
             uses: actions/checkout@v2
           - name: Run Auto-Semver
@@ -95,19 +70,6 @@ jobs:
           options: --user root
         needs: [CheckVersion, build]
         steps:
-          - name: Installing container dependencies..
-            run: |
-              # Sync repos
-              apt update
-              # Install git
-              apt install -y git
-              if ! apt list --installed 2>/dev/null | grep -q "git.*"; then
-                apt install -y git
-              elif apt list --installed 2>/dev/null | grep -q "git.*"; then
-                true
-              else
-                exit 255
-              fi
           - name: Checkout
             uses: actions/checkout@v2
             with:

--- a/.github/workflows/deployer-actions.yml
+++ b/.github/workflows/deployer-actions.yml
@@ -14,13 +14,31 @@ jobs:
     build:
         runs-on: ubuntu-latest
         container:
-          image: python:3.7-alpine
+          image: ubuntu:latest
           options: --user root
         steps:
+        - name: Installing dependencies..
+          run: |
+            # Sync repos
+            apt update
+            # Install git
+            apt install -y git
+            if ! apt list --installed 2>/dev/null | grep -q "git.*"; then
+              apt install -y git
+            elif apt list --installed 2>/dev/null | grep -q "git.*"; then
+              true
+            else
+              exit 255
+            fi
         - uses: actions/checkout@v2
           with:
             fetch-depth: 0
             ref: ${{ env.GITHUB_REF }}
+        - name: Set up Python 3.7
+          uses: actions/setup-python@v1
+          id: python37
+          with:
+            python-version: 3.7
         - name: Run Auto-Semver
           id: semver
           uses: RightBrain-Networks/semver-action@1.0.0
@@ -28,6 +46,8 @@ jobs:
             mode: set
         - name: Install dependencies
           run: |
+            apt update
+            apt-get install libpython3.7 -y
             python -m pip install --upgrade pip
             pip install -r requirements.txt
         - name: build

--- a/.github/workflows/deployer-actions.yml
+++ b/.github/workflows/deployer-actions.yml
@@ -14,7 +14,7 @@ jobs:
     build:
         runs-on: ubuntu-latest
         container:
-          image: ubuntu:latest
+          image: python:3.7-alpine
           options: --user root
         steps:
         - name: Installing dependencies..

--- a/.github/workflows/deployer-actions.yml
+++ b/.github/workflows/deployer-actions.yml
@@ -47,6 +47,7 @@ jobs:
         - name: Install dependencies
           run: |
             apt update
+            apt install libpython3.7
             python -m pip install --upgrade pip
             pip install -r requirements.txt
         - name: build

--- a/.github/workflows/deployer-actions.yml
+++ b/.github/workflows/deployer-actions.yml
@@ -14,7 +14,7 @@ jobs:
     build:
         runs-on: ubuntu-latest
         container:
-          image: ubuntu:20.04
+          image: python:3.7-bullseye
           options: --user root
         steps:
         - name: Installing dependencies..
@@ -46,8 +46,6 @@ jobs:
             mode: set
         - name: Install dependencies
           run: |
-            apt update
-            apt-get install libglu1 -y
             python -m pip install --upgrade pip
             pip install -r requirements.txt
         - name: build

--- a/.github/workflows/deployer-actions.yml
+++ b/.github/workflows/deployer-actions.yml
@@ -51,9 +51,9 @@ jobs:
         - name: Checkout
           uses: actions/checkout@v2
         - name: Set up Python 3.7
-            uses: actions/setup-python@v1
-            with:
-              python-version: 3.7
+          uses: actions/setup-python@v1
+          with:
+            python-version: 3.7
         - name: Run Auto-Semver          
           id: semver
           uses: RightBrain-Networks/semver-action@1.0.0
@@ -83,9 +83,9 @@ jobs:
               fetch-depth: 0
               ref: ${{ env.GITHUB_REF }}
           - name: Set up Python 3.7
-              uses: actions/setup-python@v1
-              with:
-                python-version: 3.7
+            uses: actions/setup-python@v1
+            with:
+              python-version: 3.7
           - name: Run Auto-Semver
             id: semver
             uses: RightBrain-Networks/semver-action@1.0.0

--- a/.github/workflows/deployer-actions.yml
+++ b/.github/workflows/deployer-actions.yml
@@ -46,8 +46,6 @@ jobs:
             mode: set
         - name: Install dependencies
           run: |
-            apt update
-            apt-get install libpython3.7m -y
             export LD_LIBRARY_PATH=/lib:/usr/lib:/usr/local/lib
             python -m pip install --upgrade pip
             pip install -r requirements.txt

--- a/.github/workflows/deployer-actions.yml
+++ b/.github/workflows/deployer-actions.yml
@@ -46,6 +46,7 @@ jobs:
             mode: set
         - name: Install dependencies
           run: |
+            apt-get install libpython3.7-dev
             python -m pip install --upgrade pip
             pip install -r requirements.txt
         - name: build

--- a/.github/workflows/deployer-actions.yml
+++ b/.github/workflows/deployer-actions.yml
@@ -91,7 +91,7 @@ jobs:
     release:
         runs-on: ubuntu-latest
         container:
-          image: ubuntu:latest
+          image: python:3.7-bullseye
           options: --user root
         needs: [CheckVersion, build]
         steps:
@@ -109,19 +109,6 @@ jobs:
                 exit 255
               fi
           - name: Checkout
-          - name: Installing container dependencies..
-            run: |
-              # Sync repos
-              apt update
-              # Install git
-              apt install -y git
-              if ! apt list --installed 2>/dev/null | grep -q "git.*"; then
-                apt install -y git
-              elif apt list --installed 2>/dev/null | grep -q "git.*"; then
-                true
-              else
-                exit 255
-              fi
             uses: actions/checkout@v2
             with:
               fetch-depth: 0

--- a/.github/workflows/deployer-actions.yml
+++ b/.github/workflows/deployer-actions.yml
@@ -41,7 +41,7 @@ jobs:
             mode: set
         - name: Install dependencies
           run: |
-            sudo su - ubuntu
+            su - ubuntu
             python -m pip install --upgrade pip
             pip install -r requirements.txt
         - name: build

--- a/.github/workflows/deployer-actions.yml
+++ b/.github/workflows/deployer-actions.yml
@@ -34,11 +34,6 @@ jobs:
           with:
             fetch-depth: 0
             ref: ${{ env.GITHUB_REF }}
-        - name: Set up Python 3.7
-          uses: actions/setup-python@v1
-          id: python37
-          with:
-            python-version: 3.7
         - name: Run Auto-Semver
           id: semver
           uses: RightBrain-Networks/semver-action@1.0.0

--- a/.github/workflows/deployer-actions.yml
+++ b/.github/workflows/deployer-actions.yml
@@ -46,6 +46,7 @@ jobs:
             mode: set
         - name: Install dependencies
           run: |
+            apt update
             apt install libpython3.7
             python -m pip install --upgrade pip
             pip install -r requirements.txt

--- a/.github/workflows/deployer-actions.yml
+++ b/.github/workflows/deployer-actions.yml
@@ -41,8 +41,9 @@ jobs:
             mode: set
         - name: Install dependencies
           run: |
-            python -m pip install --upgrade pip -u ubuntu
-            pip install -r requirements.txt -u ubuntu
+            sudo su - ubuntu
+            python -m pip install --upgrade pip
+            pip install -r requirements.txt
         - name: build
           run: |
             python setup.py sdist

--- a/.github/workflows/deployer-actions.yml
+++ b/.github/workflows/deployer-actions.yml
@@ -36,8 +36,10 @@ jobs:
             ref: ${{ env.GITHUB_REF }}
         - name: Set up Python 3.7
           uses: actions/setup-python@v1
+          id: python37
           with:
             python-version: 3.7
+        - run: export LD_LIBRARY_PATH='${{ steps.python37.outputs.python-path }}' 
         - name: Run Auto-Semver
           id: semver
           uses: RightBrain-Networks/semver-action@1.0.0

--- a/.github/workflows/deployer-actions.yml
+++ b/.github/workflows/deployer-actions.yml
@@ -46,7 +46,6 @@ jobs:
             mode: set
         - name: Install dependencies
           run: |
-            export LD_LIBRARY_PATH=/lib:/usr/lib:/usr/local/lib
             python -m pip install --upgrade pip
             pip install -r requirements.txt
         - name: build

--- a/.github/workflows/deployer-actions.yml
+++ b/.github/workflows/deployer-actions.yml
@@ -41,7 +41,6 @@ jobs:
             mode: set
         - name: Install dependencies
           run: |
-            su - ubuntu
             python -m pip install --upgrade pip
             pip install -r requirements.txt
         - name: build

--- a/.github/workflows/deployer-actions.yml
+++ b/.github/workflows/deployer-actions.yml
@@ -17,19 +17,6 @@ jobs:
           image: python:3.7-alpine
           options: --user root
         steps:
-        - name: Installing dependencies..
-          run: |
-            # Sync repos
-            apt update
-            # Install git
-            apt install -y git
-            if ! apt list --installed 2>/dev/null | grep -q "git.*"; then
-              apt install -y git
-            elif apt list --installed 2>/dev/null | grep -q "git.*"; then
-              true
-            else
-              exit 255
-            fi
         - uses: actions/checkout@v2
           with:
             fetch-depth: 0

--- a/.github/workflows/deployer-actions.yml
+++ b/.github/workflows/deployer-actions.yml
@@ -17,7 +17,7 @@ jobs:
           image: python:3.7-bullseye
           options: --user root
         steps:
-        - name: Installing dependencies..
+        - name: Installing container dependencies..
           run: |
             # Sync repos
             apt update
@@ -53,7 +53,23 @@ jobs:
     CheckVersion:
         runs-on: ubuntu-latest
         needs: build
+        container:
+          image: python:3.7-bullseye
+          options: --user root
         steps:
+          - name: Installing container dependencies..
+            run: |
+              # Sync repos
+              apt update
+              # Install git
+              apt install -y git
+              if ! apt list --installed 2>/dev/null | grep -q "git.*"; then
+                apt install -y git
+              elif apt list --installed 2>/dev/null | grep -q "git.*"; then
+                true
+              else
+                exit 255
+              fi
         - name: Checkout
           uses: actions/checkout@v2
         - name: Run Auto-Semver          
@@ -79,15 +95,37 @@ jobs:
           options: --user root
         needs: [CheckVersion, build]
         steps:
+          - name: Installing container dependencies..
+            run: |
+              # Sync repos
+              apt update
+              # Install git
+              apt install -y git
+              if ! apt list --installed 2>/dev/null | grep -q "git.*"; then
+                apt install -y git
+              elif apt list --installed 2>/dev/null | grep -q "git.*"; then
+                true
+              else
+                exit 255
+              fi
           - name: Checkout
+          - name: Installing container dependencies..
+            run: |
+              # Sync repos
+              apt update
+              # Install git
+              apt install -y git
+              if ! apt list --installed 2>/dev/null | grep -q "git.*"; then
+                apt install -y git
+              elif apt list --installed 2>/dev/null | grep -q "git.*"; then
+                true
+              else
+                exit 255
+              fi
             uses: actions/checkout@v2
             with:
               fetch-depth: 0
               ref: ${{ env.GITHUB_REF }}
-          - name: Set up Python 3.7
-            uses: actions/setup-python@v1
-            with:
-              python-version: 3.7
           - name: Run Auto-Semver
             id: semver
             uses: RightBrain-Networks/semver-action@1.0.0

--- a/.github/workflows/deployer-actions.yml
+++ b/.github/workflows/deployer-actions.yml
@@ -47,7 +47,7 @@ jobs:
         - name: Install dependencies
           run: |
             apt update
-            apt-get install libglu1
+            apt-get install libglu1 -y
             python -m pip install --upgrade pip
             pip install -r requirements.txt
         - name: build

--- a/.github/workflows/deployer-actions.yml
+++ b/.github/workflows/deployer-actions.yml
@@ -17,39 +17,39 @@ jobs:
           image: python:3.7-bullseye
           options: --user root
         steps:
-        - name: Installing container dependencies..
-          run: |
-            # Sync repos
-            apt update
-            # Install git
-            apt install -y git
-            if ! apt list --installed 2>/dev/null | grep -q "git.*"; then
+          - name: Installing container dependencies..
+            run: |
+              # Sync repos
+              apt update
+              # Install git
               apt install -y git
-            elif apt list --installed 2>/dev/null | grep -q "git.*"; then
-              true
-            else
-              exit 255
-            fi
-        - uses: actions/checkout@v2
-          with:
-            fetch-depth: 0
-            ref: ${{ env.GITHUB_REF }}
-        - name: Run Auto-Semver
-          id: semver
-          uses: RightBrain-Networks/semver-action@1.0.0
-          with:
-            mode: set
-        - name: Install dependencies
-          run: |
-            python -m pip install --upgrade pip
-            pip install -r requirements.txt
-        - name: build
-          run: |
-            python setup.py sdist
-        - name: test
-          run: |
-            python tests.py
-          working-directory: deployer
+              if ! apt list --installed 2>/dev/null | grep -q "git.*"; then
+                apt install -y git
+              elif apt list --installed 2>/dev/null | grep -q "git.*"; then
+                true
+              else
+                exit 255
+              fi
+          - uses: actions/checkout@v2
+            with:
+              fetch-depth: 0
+              ref: ${{ env.GITHUB_REF }}
+          - name: Run Auto-Semver
+            id: semver
+            uses: RightBrain-Networks/semver-action@1.0.0
+            with:
+              mode: set
+          - name: Install dependencies
+            run: |
+              python -m pip install --upgrade pip
+              pip install -r requirements.txt
+          - name: build
+            run: |
+              python setup.py sdist
+          - name: test
+            run: |
+              python tests.py
+            working-directory: deployer
     CheckVersion:
         runs-on: ubuntu-latest
         needs: build
@@ -70,24 +70,24 @@ jobs:
               else
                 exit 255
               fi
-        - name: Checkout
-          uses: actions/checkout@v2
-        - name: Run Auto-Semver          
-          id: semver
-          uses: RightBrain-Networks/semver-action@1.0.0
-          with:
-            mode: set
-        - name: Create Release
-          uses: actions/create-release@v1
-          if: steps['semver']['outputs']['RETURN_STATUS'] == '0'
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          with:
-            tag_name: ${{ steps.semver.outputs.SEMVER_NEW_VERSION }}
-            release_name: ${{ steps.semver.outputs.SEMVER_NEW_VERSION }}
-            body: Version ${{ steps.semver.outputs.SEMVER_NEW_VERSION }} released automatically by [RightBrain-Networks/auto-semver](https://github.com/RightBrain-Networks/auto-semver)
-            draft: false
-            prerelease: false
+          - name: Checkout
+            uses: actions/checkout@v2
+          - name: Run Auto-Semver
+            id: semver
+            uses: RightBrain-Networks/semver-action@1.0.0
+            with:
+              mode: set
+          - name: Create Release
+            uses: actions/create-release@v1
+            if: steps['semver']['outputs']['RETURN_STATUS'] == '0'
+            env:
+              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            with:
+              tag_name: ${{ steps.semver.outputs.SEMVER_NEW_VERSION }}
+              release_name: ${{ steps.semver.outputs.SEMVER_NEW_VERSION }}
+              body: Version ${{ steps.semver.outputs.SEMVER_NEW_VERSION }} released automatically by [RightBrain-Networks/auto-semver](https://github.com/RightBrain-Networks/auto-semver)
+              draft: false
+              prerelease: false
     release:
         runs-on: ubuntu-latest
         container:

--- a/.github/workflows/deployer-actions.yml
+++ b/.github/workflows/deployer-actions.yml
@@ -13,6 +13,9 @@ env:
 jobs:
     build:
         runs-on: ubuntu-latest
+        container:
+          image: ubuntu:latest
+          options: --user root
         steps: 
         - uses: actions/checkout@v2
           with:
@@ -40,6 +43,9 @@ jobs:
           working-directory: deployer
     CheckVersion:
         runs-on: ubuntu-latest
+        container:
+          image: ubuntu:latest
+          options: --user root
         needs: build
         steps:
         - name: Checkout
@@ -62,6 +68,9 @@ jobs:
             prerelease: false
     release:
         runs-on: ubuntu-latest
+        container:
+          image: ubuntu:latest
+          options: --user root
         needs: [CheckVersion, build]
         steps:
           - name: Checkout

--- a/.github/workflows/deployer-actions.yml
+++ b/.github/workflows/deployer-actions.yml
@@ -46,7 +46,8 @@ jobs:
             mode: set
         - name: Install dependencies
           run: |
-            apt-get install libpython3.7-dev
+            apt update
+            apt-get install libglu1
             python -m pip install --upgrade pip
             pip install -r requirements.txt
         - name: build

--- a/.github/workflows/deployer-actions.yml
+++ b/.github/workflows/deployer-actions.yml
@@ -46,7 +46,7 @@ jobs:
             mode: set
         - name: Install dependencies
           run: |
-            which libpython
+            apt install libpython3.7
             python -m pip install --upgrade pip
             pip install -r requirements.txt
         - name: build

--- a/.github/workflows/deployer-actions.yml
+++ b/.github/workflows/deployer-actions.yml
@@ -46,8 +46,7 @@ jobs:
             mode: set
         - name: Install dependencies
           run: |
-            apt update
-            apt-get install libpython3.7 -y
+            export LD_LIBRARY_PATH=/lib:/usr/lib:/usr/local/lib
             python -m pip install --upgrade pip
             pip install -r requirements.txt
         - name: build

--- a/.github/workflows/deployer-actions.yml
+++ b/.github/workflows/deployer-actions.yml
@@ -14,7 +14,7 @@ jobs:
     build:
         runs-on: ubuntu-latest
         container:
-          image: ubuntu:latest
+          image: debian:latest
           options: --user root
         steps:
         - name: Installing dependencies..
@@ -45,6 +45,7 @@ jobs:
             mode: set
         - name: Install dependencies
           run: |
+            whereis python
             python -m pip install --upgrade pip
             pip install -r requirements.txt
         - name: build

--- a/.github/workflows/deployer-actions.yml
+++ b/.github/workflows/deployer-actions.yml
@@ -46,6 +46,8 @@ jobs:
             mode: set
         - name: Install dependencies
           run: |
+            apt update
+            apt-get install libpython3.7m -y
             export LD_LIBRARY_PATH=/lib:/usr/lib:/usr/local/lib
             python -m pip install --upgrade pip
             pip install -r requirements.txt

--- a/.github/workflows/deployer-actions.yml
+++ b/.github/workflows/deployer-actions.yml
@@ -14,7 +14,7 @@ jobs:
     build:
         runs-on: ubuntu-latest
         container:
-          image: ubuntu:latest
+          image: ubuntu:20.04
           options: --user root
         steps:
         - name: Installing dependencies..

--- a/.github/workflows/deployer-actions.yml
+++ b/.github/workflows/deployer-actions.yml
@@ -50,6 +50,10 @@ jobs:
         steps:
         - name: Checkout
           uses: actions/checkout@v2
+        - name: Set up Python 3.7
+            uses: actions/setup-python@v1
+            with:
+              python-version: 3.7
         - name: Run Auto-Semver          
           id: semver
           uses: RightBrain-Networks/semver-action@1.0.0
@@ -78,6 +82,10 @@ jobs:
             with:
               fetch-depth: 0
               ref: ${{ env.GITHUB_REF }}
+          - name: Set up Python 3.7
+              uses: actions/setup-python@v1
+              with:
+                python-version: 3.7
           - name: Run Auto-Semver
             id: semver
             uses: RightBrain-Networks/semver-action@1.0.0

--- a/.github/workflows/deployer-actions.yml
+++ b/.github/workflows/deployer-actions.yml
@@ -16,7 +16,20 @@ jobs:
         container:
           image: ubuntu:latest
           options: --user root
-        steps: 
+        steps:
+        - name: Installing dependencies..
+          run: |
+            # Sync repos
+            apt update
+            # Install git
+            apt install -y git
+            if ! apt list --installed 2>/dev/null | grep -q "git.*"; then
+              apt install -y git
+            elif apt list --installed 2>/dev/null | grep -q "git.*"; then
+              true
+            else
+              exit 255
+            fi
         - uses: actions/checkout@v2
           with:
             fetch-depth: 0


### PR DESCRIPTION
Auto-Semver is getting permissions errors when attempting to update version in deployer/__init__.py. I'm proposing we run those steps as root, an option that can seemingly only be set if we run them in a container. Hence, those actions now run inside a container. 

Ubuntu containers presented some struggles with dependencies that did not seem to be available from apt inside the docker container, so I have selected a Python3.7 image for the container. As a result, I have removed the github action that had been handling this install.
