### PR TITLE
Bugfix/GitHub actions permission

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -13,7 +13,7 @@ search = __version__ = 0.0.0
 replace = __version__ = {new_version}
 
 [semver]
-main_branches = development, bugfix/github_actions_permission
+main_branches = development
 major_branches = release, major
 minor_branches = feature
-patch_branches = hotfix, bugfix, task, test
+patch_branches = hotfix, bugfix, task

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -13,7 +13,7 @@ search = __version__ = 0.0.0
 replace = __version__ = {new_version}
 
 [semver]
-main_branches = development
+main_branches = development, bugfix/github_actions_permission
 major_branches = release, major
 minor_branches = feature
-patch_branches = hotfix, bugfix, task
+patch_branches = hotfix, bugfix, task, test

--- a/.github/workflows/deployer-actions.yml
+++ b/.github/workflows/deployer-actions.yml
@@ -28,7 +28,7 @@ jobs:
             git config user.email "<>"
         - name: Run Auto-Semver
           id: semver
-          uses: RightBrain-Networks/semver-action@1.0-beta.1
+          uses: RightBrain-Networks/semver-action@1.0.0
           with:
             mode: set
         - name: Install dependencies
@@ -54,7 +54,7 @@ jobs:
             git config user.email "<>"
         - name: Run Auto-Semver
           id: semver
-          uses: RightBrain-Networks/semver-action@1.0-beta.1
+          uses: RightBrain-Networks/semver-action@1.0.0
           with:
             mode: set
         - name: Create Release
@@ -83,7 +83,7 @@ jobs:
               git config user.email "<>"
           - name: Run Auto-Semver
             id: semver
-            uses: RightBrain-Networks/semver-action@1.0-beta.1
+            uses: RightBrain-Networks/semver-action@1.0.0
             with:
               mode: set
           - name: Create Release

--- a/.github/workflows/deployer-actions.yml
+++ b/.github/workflows/deployer-actions.yml
@@ -24,7 +24,7 @@ jobs:
             python-version: 3.7
         - name: Run Auto-Semver
           id: semver
-          uses: RightBrain-Networks/semver-action@1.0.0
+          uses: RightBrain-Networks/semver-action@action_test
           with:
             mode: set
         - name: Install dependencies
@@ -46,7 +46,7 @@ jobs:
           uses: actions/checkout@v2
         - name: Run Auto-Semver
           id: semver
-          uses: RightBrain-Networks/semver-action@1.0.0
+          uses: RightBrain-Networks/semver-action@action_test
           with:
             mode: set
         - name: Create Release

--- a/.github/workflows/deployer-actions.yml
+++ b/.github/workflows/deployer-actions.yml
@@ -14,8 +14,6 @@ jobs:
     build:
         runs-on: ubuntu-latest
         steps:
-        - run: git config --global user.email "you@example.com"
-        - run: git config --global user.name "Your Name"
         - uses: actions/checkout@v2
           with:
             fetch-depth: 0
@@ -24,6 +22,10 @@ jobs:
           uses: actions/setup-python@v1
           with:
             python-version: 3.7
+        - name: setup git config
+          run: |
+            git config user.name "GitHub Actions Bot"
+            git config user.email "<>"
         - name: Run Auto-Semver
           id: semver
           uses: RightBrain-Networks/semver-action@1.0-beta.1

--- a/.github/workflows/deployer-actions.yml
+++ b/.github/workflows/deployer-actions.yml
@@ -13,61 +13,55 @@ env:
 jobs:
     build:
         runs-on: ubuntu-latest
-        container:
-          image: python:3.7-bullseye
-          options: --user root
         steps:
-          - name: Checkout
-            uses: actions/checkout@v2
-            with:
-              fetch-depth: 0
-              ref: ${{ env.GITHUB_REF }}
-          - name: Run Auto-Semver
-            id: semver
-            uses: RightBrain-Networks/semver-action@1.0.0
-            with:
-              mode: set
-          - name: Install dependencies
-            run: |
-              python -m pip install --upgrade pip
-              pip install -r requirements.txt
-          - name: build
-            run: |
-              python setup.py sdist
-          - name: test
-            run: |
-              python tests.py
-            working-directory: deployer
+        - uses: actions/checkout@v2
+          with:
+            fetch-depth: 0
+            ref: ${{ env.GITHUB_REF }}
+        - name: Set up Python 3.7
+          uses: actions/setup-python@v1
+          with:
+            python-version: 3.7
+        - name: Run Auto-Semver
+          id: semver
+          uses: RightBrain-Networks/semver-action@1.0.0
+          with:
+            mode: set
+        - name: Install dependencies
+          run: |
+            python -m pip install --upgrade pip
+            pip install -r requirements.txt
+        - name: build
+          run: |
+            python setup.py sdist
+        - name: test
+          run: |
+            python tests.py
+          working-directory: deployer
     CheckVersion:
         runs-on: ubuntu-latest
         needs: build
-        container:
-          image: python:3.7-bullseye
-          options: --user root
         steps:
-          - name: Checkout
-            uses: actions/checkout@v2
-          - name: Run Auto-Semver
-            id: semver
-            uses: RightBrain-Networks/semver-action@1.0.0
-            with:
-              mode: set
-          - name: Create Release
-            uses: actions/create-release@v1
-            if: steps['semver']['outputs']['RETURN_STATUS'] == '0'
-            env:
-              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            with:
-              tag_name: ${{ steps.semver.outputs.SEMVER_NEW_VERSION }}
-              release_name: ${{ steps.semver.outputs.SEMVER_NEW_VERSION }}
-              body: Version ${{ steps.semver.outputs.SEMVER_NEW_VERSION }} released automatically by [RightBrain-Networks/auto-semver](https://github.com/RightBrain-Networks/auto-semver)
-              draft: false
-              prerelease: false
+        - name: Checkout
+          uses: actions/checkout@v2
+        - name: Run Auto-Semver
+          id: semver
+          uses: RightBrain-Networks/semver-action@1.0.0
+          with:
+            mode: set
+        - name: Create Release
+          uses: actions/create-release@v1
+          if: steps['semver']['outputs']['RETURN_STATUS'] == '0'
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          with:
+            tag_name: ${{ steps.semver.outputs.SEMVER_NEW_VERSION }}
+            release_name: ${{ steps.semver.outputs.SEMVER_NEW_VERSION }}
+            body: Version ${{ steps.semver.outputs.SEMVER_NEW_VERSION }} released automatically by [RightBrain-Networks/auto-semver](https://github.com/RightBrain-Networks/auto-semver)
+            draft: false
+            prerelease: false
     release:
         runs-on: ubuntu-latest
-        container:
-          image: python:3.7-bullseye
-          options: --user root
         needs: [CheckVersion, build]
         steps:
           - name: Checkout

--- a/.github/workflows/deployer-actions.yml
+++ b/.github/workflows/deployer-actions.yml
@@ -14,6 +14,8 @@ jobs:
     build:
         runs-on: ubuntu-latest
         steps:
+        - run: git config --global user.email "you@example.com"
+        - run: git config --global user.name "Your Name"
         - uses: actions/checkout@v2
           with:
             fetch-depth: 0

--- a/.github/workflows/deployer-actions.yml
+++ b/.github/workflows/deployer-actions.yml
@@ -22,7 +22,7 @@ jobs:
           uses: actions/setup-python@v1
           with:
             python-version: 3.7
-        - name: setup git config
+        - name: Set Up Git Config
           run: |
             git config user.name "GitHub Actions Bot"
             git config user.email "<>"
@@ -48,6 +48,10 @@ jobs:
         steps:
         - name: Checkout
           uses: actions/checkout@v2
+        - name: Set Up Git Config
+          run: |
+            git config user.name "GitHub Actions Bot"
+            git config user.email "<>"
         - name: Run Auto-Semver
           id: semver
           uses: RightBrain-Networks/semver-action@1.0-beta.1
@@ -73,9 +77,13 @@ jobs:
             with:
               fetch-depth: 0
               ref: ${{ env.GITHUB_REF }}
+          - name: Set Up Git Config
+            run: |
+              git config user.name "GitHub Actions Bot"
+              git config user.email "<>"
           - name: Run Auto-Semver
             id: semver
-            uses: RightBrain-Networks/semver-action@1.0.0
+            uses: RightBrain-Networks/semver-action@1.0-beta.1
             with:
               mode: set
           - name: Create Release

--- a/.github/workflows/deployer-actions.yml
+++ b/.github/workflows/deployer-actions.yml
@@ -24,7 +24,7 @@ jobs:
             python-version: 3.7
         - name: Run Auto-Semver
           id: semver
-          uses: RightBrain-Networks/semver-action@action_test
+          uses: RightBrain-Networks/semver-action@1.0-beta.1
           with:
             mode: set
         - name: Install dependencies
@@ -46,7 +46,7 @@ jobs:
           uses: actions/checkout@v2
         - name: Run Auto-Semver
           id: semver
-          uses: RightBrain-Networks/semver-action@action_test
+          uses: RightBrain-Networks/semver-action@1.0-beta.1
           with:
             mode: set
         - name: Create Release

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM centos/python-36-centos7
 
-USER root
-
 # Perform updates
 RUN pip install --upgrade pip
 RUN yum update -y
@@ -23,11 +21,6 @@ VOLUME /workspace
 RUN mkdir ~/.npm
 
 # Permissions
-RUN useradd -d /deployerUser deployerUser
-RUN chown -R deployerUser:deployerUser ~/.npm
-RUN chown -R deployerUser:deployerUser /workspace
 RUN chmod -R 757 ~/.npm
 
 CMD /opt/app-root/bin/deployer
-
-USER deployerUser

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,6 @@ RUN curl -sL https://rpm.nodesource.com/setup_10.x | bash -
 RUN yum install nodejs -y
 
 # Prep workspace
-RUN mkdir /workspace
-WORKDIR /workspace
-VOLUME /workspace
 RUN mkdir ~/.npm
 
 # Permissions


### PR DESCRIPTION
- Successful test is shown in "build" job here: https://github.com/RightBrain-Networks/deployer/runs/8075276660?check_suite_focus=true

- https://docs.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions

> ![Screenshot from 2022-08-29 10-43-19](https://user-images.githubusercontent.com/12090989/187253537-fa44cb41-eebf-4864-b39f-d2f8f0f92ee1.png)
> 
> ![Screenshot from 2022-08-29 12-56-47](https://user-images.githubusercontent.com/12090989/187253941-ae9fab4e-d9d3-4c86-8b4f-411b21fd6111.png)

- In order to allow the semver github action to commit, we must have a step in each job that runs git config for the Github action bot.

- All recent changes to allowing running jobs in separate containers as root were unnecessary, and will be "rolled back" by this merge.